### PR TITLE
Fix tkinter error

### DIFF
--- a/src/bdo_empire/main.py
+++ b/src/bdo_empire/main.py
@@ -178,6 +178,7 @@ class EmpireOptimizerApp(ctk.CTk):
         lodging_window = ctk.CTkToplevel(self)
         lodging_window.title("Purchased Lodging Setup")
         lodging_window.geometry("430x600")
+        lodging_window.update()
         lodging_window.grab_set()
 
         scrollable_frame = ctk.CTkScrollableFrame(lodging_window, width=400, height=500)
@@ -364,6 +365,7 @@ class EmpireOptimizerApp(ctk.CTk):
         config_window = ctk.CTkToplevel(self)
         config_window.title("Solver Configuration")
         config_window.geometry("400x250")
+        config_window.update()
         config_window.grab_set()
 
         self.config_entries = {}


### PR DESCRIPTION
Fix "grab failed: window not viewable" on Linux, caused by trying to grab focus of a window that hasn't been fully rendered yet.